### PR TITLE
Fix typos and variable names

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This custom integration provides a way to monitor sensors data and control equip
 
 This integration can be installed using HACS.
 To do it add custom *integration* repository using url: `https://github.com/tdragon/reef-pi-hass-custom/`.
-Then search for Reef Pi in in the *Integrations* section.
+Then search for Reef Pi in the *Integrations* section.
 
 ### Manual
 To install this integration manually you have to download the content of this repository to `config/custom_components/reef-pi-hass-custom` directory:
@@ -46,6 +46,6 @@ For each equipment configured in Reef Pi an outlet entity is created: `switch.{r
 ## NOTE: How to "fix" intermittent pH readings
 On some installations of this addon, it can cause Reef Pi to intermittently drop the reading from both the Reef Pi graph/database and in Home Assistant.
 
-To fix this, in Home Assistant go to Settings > Integrations > Reef-Pi integration and under "Integration entries" click on "Configure" and select "Disable pH sensir" and click on "Submit" and then click on the 3 vertical dots and select "Reload"
+To fix this, in Home Assistant go to Settings > Integrations > Reef-Pi integration and under "Integration entries" click on "Configure" and select "Disable pH sensor" and click on "Submit" and then click on the 3 vertical dots and select "Reload"
 
 To bring in pH sensor readings into Home Assistant you will need to enable the MQTT functionality from within the Reef Pi systems interface.

--- a/custom_components/reef_pi/__init__.py
+++ b/custom_components/reef_pi/__init__.py
@@ -117,7 +117,7 @@ class ReefPiDataUpdateCoordinator(DataUpdateCoordinator):
         self.has_pumps = False
         self.has_ato = False
         self.has_timers = False
-        self.has_lighs = False
+        self.has_lights = False
         self.has_camera = False
         self.has_macro = False
 
@@ -152,20 +152,20 @@ class ReefPiDataUpdateCoordinator(DataUpdateCoordinator):
     async def update_capabilities(self):
         _LOGGER.debug("Fetching capabilities")
 
-        def get_cabability(n):
-            return n in self.capabilities.keys() and self.capabilities[n]
+        def get_capability(name):
+            return name in self.capabilities.keys() and self.capabilities[name]
 
         self.capabilities = await self.api.capabilities()
         if self.capabilities:
-            self.has_temperature = get_cabability("temperature")
-            self.has_equipment = get_cabability("equipment")
-            self.has_ph = get_cabability("ph") and not self.disable_ph
-            self.has_pumps = get_cabability("doser")
-            self.has_ato = get_cabability("ato")
-            self.has_timers = get_cabability("timers")
-            self.has_lighs = get_cabability("lighting")
-            self.has_camera = get_cabability("camera")
-            self.has_macro = get_cabability("macro")
+            self.has_temperature = get_capability("temperature")
+            self.has_equipment = get_capability("equipment")
+            self.has_ph = get_capability("ph") and not self.disable_ph
+            self.has_pumps = get_capability("doser")
+            self.has_ato = get_capability("ato")
+            self.has_timers = get_capability("timers")
+            self.has_lights = get_capability("lighting")
+            self.has_camera = get_capability("camera")
+            self.has_macro = get_capability("macro")
             _LOGGER.debug("Capabilities: ok")
 
     async def update_info(self):
@@ -259,7 +259,7 @@ class ReefPiDataUpdateCoordinator(DataUpdateCoordinator):
                 _LOGGER.debug(f"Got {len(all_ph)} pH probes: {all_ph}")
 
     async def update_lights(self):
-        if self.has_lighs:
+        if self.has_lights:
             _LOGGER.debug("Fetching lights")
             lights = await self.api.lights()
             if lights:

--- a/custom_components/reef_pi/sensor.py
+++ b/custom_components/reef_pi/sensor.py
@@ -40,12 +40,12 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     _LOGGER.debug("sensor temperature: %d, pH: %d", len(sensors), len(ph_sensors))
     async_add_entities(sensors)
     async_add_entities(ph_sensors)
-    async_add_entities([ReefPiBaicInfo(coordinator)])
+    async_add_entities([ReefPiBasicInfo(coordinator)])
     async_add_entities(pumps)
     async_add_entities(atos)
 
 
-class ReefPiBaicInfo(CoordinatorEntity, SensorEntity):
+class ReefPiBasicInfo(CoordinatorEntity, SensorEntity):
     _attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
 
     def __init__(self, coordinator):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,4 @@
-"""Fixtures for trsting."""
+"""Fixtures for testing."""
 
 import pytest
 


### PR DESCRIPTION
## Summary
- fix typos in README and tests
- rename misspelled class and variable names
- adjust capability helper name

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68527869fbe4832d901c1f26674124ed