### PR TITLE
Code formatting and API helper improvements

### DIFF
--- a/custom_components/reef_pi/async_api.py
+++ b/custom_components/reef_pi/async_api.py
@@ -1,6 +1,5 @@
 """Reef Pi api wrapper"""
 
-import json
 import logging
 from datetime import datetime
 from typing import Any, Dict
@@ -53,9 +52,9 @@ class ReefApi:
         except httpx.HTTPError as exc:
             raise CannotConnect from exc
 
-        if not response.status_code == 200:
+        if response.status_code != 200:
             return {}
-        return json.loads(response.text)
+        return response.json()
 
     async def _post(self, api, payload) -> bool:
         if not self.is_authenticated():
@@ -66,7 +65,7 @@ class ReefApi:
                 url = f"{self.host}/api/{api}"
                 client.cookies = self.cookies
                 response = await client.post(url, json=payload, timeout=self.timeout)
-                return response.status_code == 200
+                return response.is_success
         except httpx.HTTPError as exc:
             raise CannotConnect from exc
 
@@ -146,9 +145,9 @@ class ReefApi:
                 url = f"{self.host}/api/inlets/{id}/read"
                 client.cookies = self.cookies
                 response = await client.post(url, json={}, timeout=self.timeout)
-                if not response.status_code == 200:
+                if response.status_code != 200:
                     return {}
-                return json.loads(response.text)
+                return response.json()
         except httpx.HTTPError as exc:
             raise CannotConnect from exc
 

--- a/tests/test_calibration_button.py
+++ b/tests/test_calibration_button.py
@@ -37,17 +37,22 @@ async def test_ph_calibration_buttons(hass, async_api_mock_instance):
         f"{async_api_mock.REEF_MOCK_URL}/api/phprobes/6/calibratepoint"
     ).respond(200, json={})
 
-    with patch("custom_components.reef_pi.__init__.PH_CALIBRATION_DELAY", 0), patch(
-        "asyncio.sleep",
-        return_value=asyncio.Future(),
-    ) as sleep_mock, patch(
-        "homeassistant.components.persistent_notification.async_create",
-        new_callable=AsyncMock,
-    ) as notify_mock, patch(
-        "custom_components.reef_pi.async_api.ReefApi.ph",
-        new_callable=AsyncMock,
-        side_effect=[{"value": -1}] + [{"value": 7.0}] * 10,
-    ) as ph_mock:
+    with (
+        patch("custom_components.reef_pi.__init__.PH_CALIBRATION_DELAY", 0),
+        patch(
+            "asyncio.sleep",
+            return_value=asyncio.Future(),
+        ) as sleep_mock,
+        patch(
+            "homeassistant.components.persistent_notification.async_create",
+            new_callable=AsyncMock,
+        ) as notify_mock,
+        patch(
+            "custom_components.reef_pi.async_api.ReefApi.ph",
+            new_callable=AsyncMock,
+            side_effect=[{"value": -1}] + [{"value": 7.0}] * 10,
+        ) as ph_mock,
+    ):
         sleep_mock.return_value.set_result(None)
         await hass.services.async_call(
             "button",


### PR DESCRIPTION
## Summary
- use httpx built-in response helpers in async_api
- update inlet API to parse JSON directly
- fix tests after formatting

## Testing
- `ruff format --check .`
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855448a5238832d8ff34bc749eb6e5a