### PR TITLE
Fix pH calibration notification awaiting

### DIFF
--- a/custom_components/reef_pi/__init__.py
+++ b/custom_components/reef_pi/__init__.py
@@ -525,20 +525,14 @@ class ReefPiDataUpdateCoordinator(DataUpdateCoordinator):
                     f" {PH_CALIBRATION_DELAY // 60} minutes."
                 )
                 create = persistent_notification.async_create
-                if inspect.iscoroutinefunction(create):
-                    await create(
-                        self.hass,
-                        message,
-                        title="Reef-Pi Calibration",
-                        notification_id=f"reef_pi_calibration_{probe_id}",
-                    )
-                else:
-                    create(
-                        self.hass,
-                        message,
-                        title="Reef-Pi Calibration",
-                        notification_id=f"reef_pi_calibration_{probe_id}",
-                    )
+                maybe_coro = create(
+                    self.hass,
+                    message,
+                    title="Reef-Pi Calibration",
+                    notification_id=f"reef_pi_calibration_{probe_id}",
+                )
+                if inspect.isawaitable(maybe_coro):
+                    await maybe_coro
 
                 end = datetime.now(UTC) + timedelta(seconds=PH_CALIBRATION_DELAY)
                 if probe_id not in self.ph:
@@ -562,20 +556,14 @@ class ReefPiDataUpdateCoordinator(DataUpdateCoordinator):
                 value = reading.get("value")
                 if value is None or value < 0:
                     create = persistent_notification.async_create
-                    if inspect.iscoroutinefunction(create):
-                        await create(
-                            self.hass,
-                            "Invalid reading detected, restarting step.",
-                            title="Reef-Pi Calibration",
-                            notification_id=f"reef_pi_calibration_{probe_id}",
-                        )
-                    else:
-                        create(
-                            self.hass,
-                            "Invalid reading detected, restarting step.",
-                            title="Reef-Pi Calibration",
-                            notification_id=f"reef_pi_calibration_{probe_id}",
-                        )
+                    maybe_coro = create(
+                        self.hass,
+                        "Invalid reading detected, restarting step.",
+                        title="Reef-Pi Calibration",
+                        notification_id=f"reef_pi_calibration_{probe_id}",
+                    )
+                    if inspect.isawaitable(maybe_coro):
+                        await maybe_coro
                     continue
 
                 await self.api.ph_probe_calibrate_point(
@@ -594,20 +582,14 @@ class ReefPiDataUpdateCoordinator(DataUpdateCoordinator):
             }
         )
         create = persistent_notification.async_create
-        if inspect.iscoroutinefunction(create):
-            await create(
-                self.hass,
-                "Two point calibration complete.",
-                title="Reef-Pi Calibration",
-                notification_id=f"reef_pi_calibration_{probe_id}",
-            )
-        else:
-            create(
-                self.hass,
-                "Two point calibration complete.",
-                title="Reef-Pi Calibration",
-                notification_id=f"reef_pi_calibration_{probe_id}",
-            )
+        maybe_coro = create(
+            self.hass,
+            "Two point calibration complete.",
+            title="Reef-Pi Calibration",
+            notification_id=f"reef_pi_calibration_{probe_id}",
+        )
+        if inspect.isawaitable(maybe_coro):
+            await maybe_coro
         await self.async_request_refresh()
 
     async def timer_control(self, id, state):


### PR DESCRIPTION
## Summary
- fix detection of awaitables when creating notifications during pH probe calibration

## Testing
- `pre-commit run --files custom_components/reef_pi/__init__.py custom_components/reef_pi/button.py tests/test_calibration_button.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858c77389c8832d95682bc4f0e18d43