### PR TITLE
Handle calibration return data

### DIFF
--- a/custom_components/reef_pi/__init__.py
+++ b/custom_components/reef_pi/__init__.py
@@ -510,7 +510,10 @@ class ReefPiDataUpdateCoordinator(DataUpdateCoordinator):
         await self.api.ph_probe_calibrate_point(probe_id, expected, observed, type_)
 
     async def calibrate_ph_probe_two_point(self, probe_id: int, mode: str):
-        """Run a two point pH probe calibration with user prompts."""
+        """Run a two point pH probe calibration with user prompts.
+
+        Returns ``True`` once the calibration completes.
+        """
         low, high = PH_CALIBRATION_MODES.get(mode, PH_CALIBRATION_MODES["freshwater"])
         steps = [
             ("low", low),
@@ -591,6 +594,7 @@ class ReefPiDataUpdateCoordinator(DataUpdateCoordinator):
         if inspect.isawaitable(maybe_coro):
             await maybe_coro
         await self.async_request_refresh()
+        return True
 
     async def timer_control(self, id, state):
         await self.api.timer_control(id, state)

--- a/custom_components/reef_pi/button.py
+++ b/custom_components/reef_pi/button.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 from homeassistant.components.button import (
     ButtonEntity,
 )
+import logging
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
-
 from .const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
@@ -139,4 +141,12 @@ class ReefPiPhCalibrationButton(CoordinatorEntity, ButtonEntity):
         return self._probe_id in self.api.ph.keys()
 
     async def async_press(self) -> None:
-        await self.api.calibrate_ph_probe_two_point(self._probe_id, self._mode)
+        calibration = await self.api.calibrate_ph_probe_two_point(
+            self._probe_id, self._mode
+        )
+        _LOGGER.debug(
+            "pH probe %s calibrated (mode=%s): %s",
+            self._probe_id,
+            self._mode,
+            calibration,
+        )


### PR DESCRIPTION
## Summary
- log calibration result when pressing pH calibration button
- return boolean from `calibrate_ph_probe_two_point`

## Testing
- `pre-commit run -a`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858f15243a4832d954b428024347b11